### PR TITLE
Rename the default topic from “/World” to “world”

### DIFF
--- a/priv/www/assets/js/dashboard.js
+++ b/priv/www/assets/js/dashboard.js
@@ -1222,12 +1222,12 @@
                         useSSL : false 
                     },
                     subInfo : {
-                        topic : '/world',
+                        topic : 'world',
                         qos : 0
                     },
                     subscriptions : [],
                     sendInfo : {
-                        topic : '/world',
+                        topic : 'world',
                         text : 'Hello world!',
                         qos : 0,
                         retained : true

--- a/priv/www/assets/js/mqttws31.js
+++ b/priv/www/assets/js/mqttws31.js
@@ -63,10 +63,10 @@ client.connect({onSuccess:onConnect});
 function onConnect() {
   // Once a connection has been made, make a subscription and send a message.
   console.log("onConnect");
-  client.subscribe("/World");
+  client.subscribe("world");
   message = new Paho.MQTT.Message("Hello");
-  message.destinationName = "/World";
   client.send(message); 
+  message.destinationName = "world";
 };
 function onConnectionLost(responseObject) {
   if (responseObject.errorCode !== 0)

--- a/priv/www/websocket.html
+++ b/priv/www/websocket.html
@@ -147,7 +147,7 @@
                     <div class="form-group">
                         <label for="subscription">Subscription:</label> <input type="text"
                             class="form-control"
-                            placeholder="Subscription" value="/World" v-model="subInfo.topic">
+                            placeholder="Subscription" value="world" v-model="subInfo.topic">
                     </div>
                     </div>
                     <div class="col-sm-6">
@@ -212,7 +212,7 @@
                     <div class="form-group">
                         <label for="topic">Topic:</label> <input type="text"
                             class="form-control" id="topic"
-                            placeholder="Topic" value="/World" v-model="sendInfo.topic">
+                            placeholder="Topic" value="world" v-model="sendInfo.topic">
                     </div>
                     </div>
                     


### PR DESCRIPTION
Seems it's not a good practice to use a leading slash in topic names. It adds an unnecessary topic level with an empty parent.