### PR TITLE
Add default administrator user config

### DIFF
--- a/etc/emq_dashboard.conf
+++ b/etc/emq_dashboard.conf
@@ -3,6 +3,12 @@
 ##--------------------------------------------------------------------
 
 ##--------------------------------------------------------------------
+## HTTP default users
+
+dashboard.default_user.login = admin
+dashboard.default_user.password = public
+
+##--------------------------------------------------------------------
 ## HTTP Listener
 
 ## The IP address and port that the Dashboard HTTP listener will bind.

--- a/priv/emq_dashboard.schema
+++ b/priv/emq_dashboard.schema
@@ -139,7 +139,6 @@
         case cuttlefish:conf_get(Prefix, Conf, undefined) of
             undefined -> [];
             Port      ->
-                io:format("~p~n", [LisOpts(Prefix)]),
                 [{Proto, Port, case Proto of
                                    http  -> LisOpts(Prefix);
                                    https -> [{sslopts, SslOpts(Prefix)} | LisOpts(Prefix)]

--- a/priv/emq_dashboard.schema
+++ b/priv/emq_dashboard.schema
@@ -1,5 +1,14 @@
 %%-*- mode: erlang -*-
 %% emq_dashboard config mapping
+
+{mapping, "dashboard.default_user.login", "emq_dashboard.default_user_username", [
+  {datatype, string}
+]}.
+
+{mapping, "dashboard.default_user.password", "emq_dashboard.default_user_passwd", [
+  {datatype, string}
+]}.
+
 {mapping, "dashboard.listener.http", "emq_dashboard.listeners", [
   {datatype, [integer, ip]}
 ]}.

--- a/src/emq_dashboard_admin.erl
+++ b/src/emq_dashboard_admin.erl
@@ -139,10 +139,7 @@ init([]) ->
     %% Wait???
     %% mnesia:wait_for_tables([mqtt_admin], 5000),
     % Init mqtt_admin table
-    case needs_defaut_user() of
-        true  -> insert_default_user();
-        false -> ok
-    end,
+    add_default_user(binenv(default_user_username), binenv(default_user_passwd)),
     {ok, state}.
 
 handle_call(_Req, _From, State) ->
@@ -176,15 +173,15 @@ salt() ->
     Salt = random:uniform(16#ffffffff),
     <<Salt:32>>.
 
-needs_defaut_user() ->
-    is_empty(mqtt_admin).
+binenv(Key) ->
+    iolist_to_binary(application:get_env(emq_dashboard, Key, "")).
 
-is_empty(Tab) ->
-    mnesia:dirty_first(Tab) == '$end_of_table'.
+add_default_user(Username, Password) when ?EMPTY_KEY(Username) orelse ?EMPTY_KEY(Password) ->
+    igonre;
 
-insert_default_user() ->
-    Admin = #mqtt_admin{username = <<"admin">>,
-                        password = hash(<<"public">>),
-                        tags = <<"administrator">>},
-    mnesia:transaction(fun mnesia:write/1, [Admin]).
+add_default_user(Username, Password) ->
+    case lookup_user(Username) of
+        [] -> add_user(Username, Password, <<"administrator">>);
+        _  -> ok
+    end.
 


### PR DESCRIPTION
1. Add default administrator user config
2. Fix EMQ launch failed error
    (casued by `io:format(...)` statementat in the `emq_dashboard.schema` file)